### PR TITLE
Login patch to reject emails >321 chars

### DIFF
--- a/app/login.tsx
+++ b/app/login.tsx
@@ -71,6 +71,11 @@ export default function LoginScreen() {
       return;
     }
 
+    if(text.length > 321){
+      alert("Email too long. Please ensure that email is at most 321 characters.")
+      return;
+    }
+
     try {
         const response = await fetch('http://localhost:5000/login', {
           method: 'POST',

--- a/app/signUp.tsx
+++ b/app/signUp.tsx
@@ -53,6 +53,11 @@ export default function LoginScreen() {
       return;
     }
 
+    if(text.length > 321){
+      alert("Email too long. Please ensure that email is at most 321 characters.")
+      return;
+    }
+
     try {
         const response = await fetch('http://localhost:5000/signUp', {
           method: 'POST',


### PR DESCRIPTION
3.02.25: Don't allow emails greater than 321 chars in length. This prevents DB overflow and related issues.

Error handling related to issue #17 and #1.