### PR TITLE
Add multiplier & some light frontend tweaks

### DIFF
--- a/app/answerchoices.tsx
+++ b/app/answerchoices.tsx
@@ -531,7 +531,7 @@ const styles = StyleSheet.create({
     position: "absolute",
     top: 10,
     right: 15,
-    fontSize: 30,
+    fontSize: 40,
     color: "white",
   },
   question: {

--- a/app/correct.tsx
+++ b/app/correct.tsx
@@ -14,7 +14,7 @@ interface CorrectScreenProps {
   onBonusSelect: (bonus: string) => void;
 }
 
-const CorrectScreen: React.FC<CorrectScreenProps> = ({ timer = 13, onBonusSelect }) => {
+const CorrectScreen: React.FC<CorrectScreenProps> = ({ timer = "", onBonusSelect }) => {
   const [selectedBonus, setSelectedBonus] = useState<string | null>(null);
   const questionNumber = useStudentStore(state => state.currQuestionNum);
   const totalQuestions = useStudentStore(state => state.totalQuestions);
@@ -43,7 +43,19 @@ const CorrectScreen: React.FC<CorrectScreenProps> = ({ timer = 13, onBonusSelect
     }
   }, [bonus])
 
+  //for multipliers
+  const setPointsPer = useStudentStore(state => state.setPointsPerClick);
+  const pointsPer = useStudentStore(state => state.pointsPerClick);
+  useEffect(() => {
+    if(bonus === "+1 points per click"){
+      setPointsPer(pointsPer+1);
+    }
+    else if(bonus === "+2 points per click"){
+      setPointsPer(pointsPer+2);
+    }
+  }, [bonus])
 
+  
   const handleBonusSelect = (bonus: string) => {
     setSelectedBonus(bonus);
     // Was throwing an error when onBonusSelect was not a function, added check against until it is implemented

--- a/app/endgame.tsx
+++ b/app/endgame.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { View, Text, StyleSheet, Pressable } from "react-native";
 import { Link, router } from "expo-router";
 import { useStudentStore } from "./useWebSocketStore";
 import { WebSocketService } from "./webSocketService";
 import { CommonActions } from "@react-navigation/native";
+import Config from './config';
 
 const GameSummaryScreen = () => {
   const playerName = useStudentStore((state) => state.name);
@@ -30,6 +31,54 @@ const GameSummaryScreen = () => {
     }));
   };
 
+  //get values for "you got __ out of __ correct" description
+  const code = useStudentStore(state => state.roomCode);
+  
+  const [correctCount, setCorrectCount] = useState(0);
+  const [incorrectCount, setIncorrectCount] = useState(0);
+  const [totalCount, setTotalCount] = useState(0);
+
+    useEffect(() => {
+        const getReview = async () => {
+          //get decks from backend
+          try {
+            const response = await fetch(`${Config.BE_HOST}/review/${code}/${playerName}`, {
+              method: 'GET',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              credentials: 'include',
+            });
+    
+            const data = await response.json();
+    
+            if (!response.ok) {
+              alert("Unable to get review. Please try again.");
+              return;
+            }
+
+            let correct = 0;
+            let incorrect = 0;
+    
+            data.forEach((deck: any) => {
+              if (deck.fld_correctness === true) correct++;
+              if (deck.fld_correctness === false) incorrect++;
+            });
+    
+            // update state
+            setCorrectCount(correct);
+            setIncorrectCount(incorrect);
+            setTotalCount(correct+incorrect);
+          }
+          catch(error) {
+            console.log("Error during fetch:", error);
+            alert("Server error, please try again later.");
+          }
+        }
+    
+        getReview();
+    }, []);
+
   return (
     <View style={styles.container}>
       <View style={styles.header}>
@@ -41,7 +90,7 @@ const GameSummaryScreen = () => {
         You earned <Text style={styles.boldText}>{clickCount}</Text> points and
       </Text>
       <Text style={styles.description}>
-        answered <Text style={styles.boldText}>12</Text> out of <Text style={styles.boldText}>13</Text> questions correctly.
+        answered <Text style={styles.boldText}>{correctCount}</Text> out of <Text style={styles.boldText}>{totalCount}</Text> questions correctly.
       </Text>
       <View style={styles.buttonContainer}>
         <Pressable onPress={reviewPress} style={styles.buttonBlue}>

--- a/app/finalscorers.tsx
+++ b/app/finalscorers.tsx
@@ -111,9 +111,9 @@ const TopScorersScreen = () => {
           <View style={styles.headerLeft}>
             <Text style={styles.logo}>Tappt</Text>
           </View>
-          <View style={styles.headerRight}>
-            <Text style={styles.playerCountText}>17 players</Text>
-          </View>
+          {/* {<View style={styles.headerRight}>
+            <Text style={styles.playerCountText}>{totalPlayers} players</Text>
+          </View>} */}
         </View>
         <View style={styles.headerTitleContainer}>
           <Text style={styles.headerText}>Top Scorers</Text>

--- a/app/questiontimer.tsx
+++ b/app/questiontimer.tsx
@@ -30,6 +30,10 @@ const QuestionWithTimerScreen: React.FC<QuestionWithTimerScreenProps> = ({
   }, [timerIsUp, haveAllStudentsAnswered])
 
 
+  //player count for header
+  const players = useStudentStore((state) => state.students);
+  const totalPlayers = players.length;
+
 const [questions, setQuestions] = useState<QuestionWithTimerScreenProps[]>([]);
 const deckID = useStudentStore(state => state.deckID);
 const currQuestionNum = useStudentStore(state => state.currQuestionNum);
@@ -133,7 +137,7 @@ useEffect(() => {
   return (
     <View style={styles.container}>
       <Text style={styles.header}>Tappt</Text>
-      <Text style={styles.players}>{playerCount} players</Text>
+      <Text style={styles.players}>{totalPlayers} players</Text>
 
       <Text style={styles.timer}>{timer}</Text>
       <Text style={styles.question}>{questions[currQuestionNum]?.question || "questions are done. will need appriopriate routing for this."}</Text>

--- a/app/reading.tsx
+++ b/app/reading.tsx
@@ -27,7 +27,7 @@ async function playSound(e: any) {
   }, 1500);
 }
 
-const ReadingScreen: React.FC<ReadingScreenProps> = ({ playerCount = 17 }) => {
+const ReadingScreen: React.FC<ReadingScreenProps> = () => {
   const [isReadingComplete, setIsReadingComplete] = useState(false);
 
   const navigation = useNavigation(); // <- Hook into navigation
@@ -43,6 +43,11 @@ const ReadingScreen: React.FC<ReadingScreenProps> = ({ playerCount = 17 }) => {
   //testing
   const nextQ = useStudentStore(state => state.nextQuestion);
   const setNextQuestion = useStudentStore(state => state.setNextQuestion);
+
+
+  //player count for header
+  const players = useStudentStore((state) => state.students);
+  const totalPlayers = players.length;
 
   //------------ Setting up the questions -----------------
 const deckID = useStudentStore(state => state.deckID);
@@ -260,7 +265,7 @@ if (isReadingComplete) {
   return (
     <View style={styles.container}>
       <Text style={styles.header}>Tappt</Text>
-      <Text style={styles.players}>{playerCount} players</Text>
+      <Text style={styles.players}>{totalPlayers} players</Text>
       <Text style={styles.readingText}>Reading...</Text>
     </View>
   );

--- a/app/roundScorers.tsx
+++ b/app/roundScorers.tsx
@@ -37,6 +37,10 @@ useEffect(() => {
     router.replace("/reading");
   };
 
+  //player count for header
+  const players = useStudentStore((state) => state.students);
+  const totalPlayers = players.length;
+
   //function called for front end formatting for top 4 students
   const ScoreRow = ({ label, clicks, color }) => {
     return (
@@ -55,7 +59,7 @@ useEffect(() => {
             <Text style={styles.logo}>Tappt</Text>
           </View>
           <View style={styles.headerRight}>
-            <Text style={styles.playerCountText}>17 players</Text>
+            <Text style={styles.playerCountText}>{totalPlayers} players</Text>
           </View>
         </View>
         <View style={styles.headerTitleContainer}>
@@ -68,7 +72,7 @@ useEffect(() => {
         {topStudents[1] && (<ScoreRow label={`2 ${topStudents[1].name}`} clicks={`${topStudents[1].clickCount} clicks`} color={"#EFB034FF"}/>)}
         {topStudents[2] && (<ScoreRow label={`3 ${topStudents[2].name}`} clicks={`${topStudents[2].clickCount} clicks`} color={"#7F55E0FF"}/>)}
         {topStudents[3] && (<ScoreRow label={`4 ${topStudents[3].name}`} clicks={`${topStudents[3].clickCount} clicks`} color={"#EA916EFF"}/>)}
-        {topStudents.length === 0 && (<Text>No players on leaderboard.</Text>)}
+        {topStudents.length === 0 && (<Text style={styles.noPlayersText}>No players on leaderboard.</Text>)}
 
         <TouchableOpacity style={[styles.button]} onPress={handlePress}>
           <Text style={[styles.buttonText]}>Continue →</Text>
@@ -123,6 +127,13 @@ const styles = StyleSheet.create({
   headerText: {
     fontSize: 70,
     fontWeight: "bold",
+    color: "#FFFFFF",
+  },
+  noPlayersText: {
+    marginTop: 50,
+    marginBottom: 50,
+    fontSize: 40,
+    fontWeight: "normal",
     color: "#FFFFFF",
   },
   scoreRow: {

--- a/app/studentClicks.tsx
+++ b/app/studentClicks.tsx
@@ -12,6 +12,9 @@ export default function studentClicksScreen() {
   const setIsClickable = useStudentStore(state => state.setIsClickable) //fxn to turn click listening on/off
   const clickIncrement = useStudentStore(state => state.incClickCount); //fxn for clickcount + inc value
 
+  const pointsPer = useStudentStore(state => state.pointsPerClick);         //for multiplier bonus
+  console.log("this student gets ", pointsPer, " points per click.");
+
   //for when reading is completed
   const completedReading = useStudentStore(state => state.completedReading);
   const setCompletedReading = useStudentStore(state => state.setCompletedReading);
@@ -36,7 +39,7 @@ export default function studentClicksScreen() {
       if(isClickable){
         //console.log("Is clickable!");
         const handleClick = () => {
-          clickIncrement(1);
+          clickIncrement(pointsPer);
         };
 
         document.addEventListener('click', handleClick);
@@ -55,7 +58,7 @@ export default function studentClicksScreen() {
     if(isClickable){
       const handleSpace = (event: KeyboardEvent) => {
         if (event.code === "Space") {
-          clickIncrement(1);
+          clickIncrement(pointsPer);
         }
       };
 

--- a/app/useWebSocketStore.ts
+++ b/app/useWebSocketStore.ts
@@ -16,6 +16,7 @@ interface StudentState {
     name: string; //stores the user's name
     userType?: "student" | "teacher"; //stores the user's type
     clickCount: number;
+    pointsPerClick: number;
 
 
     //game properties
@@ -47,7 +48,7 @@ interface StudentState {
     setName: (name: string) => void;
     setUserType: (userType: "student" | "teacher") => void;
     incClickCount: (by: number) => void;
-
+    setPointsPerClick: (pointsPerClick: number) => void;
     
     //sets - game properties
     setRoomCode: (roomCode: string) => void;
@@ -77,6 +78,7 @@ export const useStudentStore = create<StudentState>((set, get) => ({ //creates a
     name: "",
     userType: undefined,
     clickCount: 0,
+    pointsPerClick: 1,
 
     //game
     roomCode: "",
@@ -122,6 +124,11 @@ export const useStudentStore = create<StudentState>((set, get) => ({ //creates a
             return { clickCount: newCount };
         });
     },
+    setPointsPerClick: (pointsPerClick) => {
+        console.log("new points per click: ", pointsPerClick);
+        set({ pointsPerClick })
+    },
+
 
 
     //game
@@ -152,6 +159,7 @@ export const useStudentStore = create<StudentState>((set, get) => ({ //creates a
             students: [],
             currentTime: 30,
             clickCount: 0,
+            pointsPerClick: 1,
             isClickable: false,
             deckID: -1,
             startedGame: false,

--- a/app/webSocketService.ts
+++ b/app/webSocketService.ts
@@ -79,6 +79,7 @@ export const WebSocketService = {
                         totalQuestions: 0,
                         currQuestionNum: 0,
                         clickCount: 0,
+                        pointsPerClick: 1,
                         students: [],
                         deckID: -1,
                         roomCode: "",

--- a/backend/backend-server.js
+++ b/backend/backend-server.js
@@ -801,10 +801,10 @@ const bonusDecider = async (name, qNum) => {
     else if (bonusProb > 45 && bonusProb <= 60) {
       yourBonus = "20% Bonus";
     }
-    else if (bonusProb > 60 && bonusProb <= 85) {
+    else if (bonusProb > 60 && bonusProb <= 95) {
       yourBonus = "+1 points per click";
     }
-    else if (bonusProb > 85) {
+    else if (bonusProb > 95) {
       yourBonus = "+2 points per click";
     }
     else {
@@ -821,10 +821,10 @@ const bonusDecider = async (name, qNum) => {
     else if (bonusProb > 35 && bonusProb <= 60) {
       yourBonus = "20% Bonus";
     }
-    else if (bonusProb > 60 && bonusProb <= 75) {
+    else if (bonusProb > 60 && bonusProb <= 90) {
       yourBonus = "+1 points per click";
     }
-    else if (bonusProb > 75) {
+    else if (bonusProb > 90) {
       yourBonus = "+2 points per click";
     }
     else {

--- a/backend/backend-server.js
+++ b/backend/backend-server.js
@@ -802,10 +802,10 @@ const bonusDecider = async (name, qNum) => {
       yourBonus = "20% Bonus";
     }
     else if (bonusProb > 60 && bonusProb <= 85) {
-      yourBonus = "1.5x Multiplier";
+      yourBonus = "+1 points per click";
     }
     else if (bonusProb > 85) {
-      yourBonus = "2x Multiplier";
+      yourBonus = "+2 points per click";
     }
     else {
       yourBonus = "failed";
@@ -822,10 +822,10 @@ const bonusDecider = async (name, qNum) => {
       yourBonus = "20% Bonus";
     }
     else if (bonusProb > 60 && bonusProb <= 75) {
-      yourBonus = "1.5x Multiplier";
+      yourBonus = "+1 points per click";
     }
     else if (bonusProb > 75) {
-      yourBonus = "2x Multiplier";
+      yourBonus = "+2 points per click";
     }
     else {
       yourBonus = "failed";


### PR DESCRIPTION
4/25/25: Implement multiplier power-up as outlined in issue #134. Note that multipliers are simply increments to a student's points-per-click value, either a single increment or a double increment (for now). Completes power-up handling outlined in issue #119. 

Also completed endgame description ("you answered __ out of __ questions correctly") and modified some header values and sizes to help with UI consistency.